### PR TITLE
Don't use doLast

### DIFF
--- a/src/main/java/org/walkmod/Scalafix.java
+++ b/src/main/java/org/walkmod/Scalafix.java
@@ -1,47 +1,72 @@
 package org.walkmod;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.scala.ScalaCompile;
 
+import java.io.File;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Scalafix extends DefaultTask {
 
-  public void stdOut(ScalafixExtension extension) {
-    scalafix.v1.Main.main(args(extension, "--stdout"));
+  @Input
+  private String getClasspath() {
+    List<String> classesDir = getProject().getConvention().getPlugin(JavaPluginConvention.class).getSourceSets()
+            .stream().flatMap(sourceSet -> sourceSet.getOutput().getClassesDirs().getFiles().stream())
+            .map(File::getPath)
+            .collect(Collectors.toList());
+    return String.join(File.pathSeparator, classesDir);
   }
 
-  public void apply(ScalafixExtension extension) {
-    scalafix.v1.Main.main(args(extension, null));
+  @Input
+  private String getAdditionalParameters() {
+    List<String> additionalParametersList = getProject().getTasks().withType(ScalaCompile.class).stream().findFirst()
+            .map(compile ->
+                    compile.getScalaCompileOptions().getAdditionalParameters())
+            .orElse(Collections.emptyList());
+    return String.join(",", additionalParametersList);
   }
 
-  public void diffBase(ScalafixExtension extension) {
-    scalafix.v1.Main.main(args(extension, "--diff-base"));
+  @Input
+  private String getSourceRoot() {
+    return getProject().getRootDir().getAbsolutePath();
   }
 
-  public void diff(ScalafixExtension extension) {
-    scalafix.v1.Main.main(args(extension,"--diff"));
-  }
+  @Input
+  String action = null;
 
-  private String[] args(ScalafixExtension extension, String action) {
-    List<String> args = new LinkedList<String>();
+  @Input
+  boolean isVerbose = false;
+
+  private String[] args(String action) {
+    List<String> args = new LinkedList<>();
     if (action != null) {
       args.add(action);
     }
     args.add("--config");
-    args.add(extension.getSourceRoot() + "/.scalafix.conf");
-    if (extension.isVerbose()) {
+    args.add(getSourceRoot() + "/.scalafix.conf");
+    if (isVerbose) {
       args.add("--verbose");
     }
     args.add("--scalacOptions");
-    args.add(extension.getScalaOptions());
+    args.add(getAdditionalParameters());
     args.add("--sourceroot");
-    args.add(extension.getSourceRoot());
+    args.add(getSourceRoot());
     args.add("--classpath");
-    args.add(extension.getClassPath());
+    args.add(getClasspath());
     args.add("--no-sys-exit");
     String[] result = new String[args.size()];
     args.toArray(result);
     return result;
+  }
+
+  @TaskAction
+  public void run() {
+    scalafix.v1.Main.main(args(action));
   }
 }

--- a/src/main/java/org/walkmod/ScalafixExtension.java
+++ b/src/main/java/org/walkmod/ScalafixExtension.java
@@ -4,41 +4,11 @@ public class ScalafixExtension {
 
   private boolean isVerbose;
 
-  private String classPath;
-
-  private String scalaOptions = "";
-
-  private String sourceRoot = "";
-
   public boolean isVerbose() {
     return isVerbose;
   }
 
   public void setVerbose(boolean verbose) {
     isVerbose = verbose;
-  }
-
-  public String getScalaOptions() {
-    return scalaOptions;
-  }
-
-  public void setScalaOptions(String scalaOptions) {
-    this.scalaOptions = scalaOptions;
-  }
-
-  public String getClassPath() {
-    return classPath;
-  }
-
-  public void setClassPath(String classPath) {
-    this.classPath = classPath;
-  }
-
-  public String getSourceRoot() {
-    return sourceRoot;
-  }
-
-  public void setSourceRoot(String sourceRoot) {
-    this.sourceRoot = sourceRoot;
   }
 }

--- a/src/main/java/org/walkmod/ScalafixPlugin.java
+++ b/src/main/java/org/walkmod/ScalafixPlugin.java
@@ -2,69 +2,31 @@ package org.walkmod;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.tasks.scala.ScalaCompile;
-
-import java.io.File;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class ScalafixPlugin implements Plugin<Project> {
 
   private static String EXTENSION = "scalafix";
 
-  private String getClasspath(Project project) {
-    List<String> classesDir = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets()
-            .stream().flatMap(sourceSet -> sourceSet.getOutput().getClassesDirs().getFiles().stream())
-            .map(File::getPath)
-            .collect(Collectors.toList());
-    return String.join(File.pathSeparator, classesDir);
-  }
-
-  private String getAdditionalParameters(Project project) {
-    List<String> additionalParametersList = project.getTasks().withType(ScalaCompile.class).stream().findFirst()
-            .map(compile ->
-                    compile.getScalaCompileOptions().getAdditionalParameters())
-            .orElse(Collections.emptyList());
-    String addionalParameters = String.join(",", additionalParametersList);
-    return addionalParameters;
-  }
-
   public void apply(Project project) {
     ScalafixExtension extension = project.getExtensions().create(EXTENSION, ScalafixExtension.class);
 
-    Scalafix scalaFix = project.getTasks().create("scalafix", Scalafix.class);
-    scalaFix.doLast((task) -> {
-      extension.setClassPath(getClasspath(project));
-      extension.setScalaOptions(getAdditionalParameters(project));
-      extension.setSourceRoot(project.getRootDir().getAbsolutePath());
-      scalaFix.apply(extension);
+    project.getTasks().register("scalafix", Scalafix.class, scalafix -> {
+      scalafix.isVerbose = extension.isVerbose();
     });
 
-
-    Scalafix scalaFixStdout = project.getTasks().create("scalafixStdout", Scalafix.class);
-    scalaFixStdout.doLast((task) -> {
-      extension.setClassPath(getClasspath(project));
-      extension.setScalaOptions(getAdditionalParameters(project));
-      extension.setSourceRoot(project.getRootDir().getAbsolutePath());
-      scalaFixStdout.stdOut(extension);
+    project.getTasks().register("scalafixStdout", Scalafix.class, scalafix -> {
+      scalafix.isVerbose = extension.isVerbose();
+      scalafix.action = "--stdout";
     });
 
-    Scalafix scalaFixDiff = project.getTasks().create("scalafixDiff", Scalafix.class);
-    scalaFixDiff.doLast((task) -> {
-      extension.setClassPath(getClasspath(project));
-      extension.setScalaOptions(getAdditionalParameters(project));
-      extension.setSourceRoot(project.getRootDir().getAbsolutePath());
-      scalaFixDiff.diff(project.getExtensions().getByType(ScalafixExtension.class));
+    project.getTasks().register("scalafixDiff", Scalafix.class, scalafix -> {
+      scalafix.isVerbose = extension.isVerbose();
+      scalafix.action = "--diff";
     });
 
-    Scalafix scalaFixDiffBase = project.getTasks().create("scalafixDiffBase",  Scalafix.class);
-    scalaFixDiffBase.doLast((task) -> {
-      extension.setClassPath(getClasspath(project));
-      extension.setScalaOptions(getAdditionalParameters(project));
-      extension.setSourceRoot(project.getRootDir().getAbsolutePath());
-      scalaFixDiffBase.diffBase(extension);
+    project.getTasks().register("scalafixDiffBase",  Scalafix.class, scalafix -> {
+      scalafix.isVerbose = extension.isVerbose();
+      scalafix.action = "--diff-base";
     });
 
   }


### PR DESCRIPTION
Instead of using doLast now the task is reading the project values directly and adding a @TaskAction method that runs the task.

For the extension values we use the configuration ( the third parameter to the create/register ), but there is no test for the isVerbose, so no prove it worked before or still works now.

About create/register, Gradle is pushing to the new api, using register, the difference is that create is configuring the tasks ahead of time while register creates a placeholder ( `TaskProvider` to be precise ) and it will only configure the tasks when they are in the execution graph.